### PR TITLE
Remove unnecessary line breaks and white spaces to save LLM tokens

### DIFF
--- a/openai/templates.go
+++ b/openai/templates.go
@@ -40,10 +40,10 @@ func generateDDLRoughly(s *schema.Schema) string {
 		if t.Type == "VIEW" {
 			continue
 		}
-		ddl += fmt.Sprintf("CREATE TABLE %s (\n", t.Name)
+		ddl += fmt.Sprintf("CREATE TABLE %s (", t.Name)
 		td := []string{}
 		for _, c := range t.Columns {
-			d := fmt.Sprintf("  %s %s", c.Name, c.Type)
+			d := fmt.Sprintf("%s %s", c.Name, c.Type)
 			if c.Default.String != "" {
 				d += fmt.Sprintf(" DEFAULT %s", c.Default.String)
 			}
@@ -56,7 +56,7 @@ func generateDDLRoughly(s *schema.Schema) string {
 			td = append(td, d)
 		}
 		for _, i := range t.Indexes {
-			d := fmt.Sprintf("  %s", i.Def)
+			d := i.Def
 			td = append(td, d)
 		}
 		for _, c := range t.Constraints {
@@ -64,15 +64,15 @@ func generateDDLRoughly(s *schema.Schema) string {
 			case "PRIMARY KEY", "UNIQUE KEY":
 				continue
 			default:
-				d := fmt.Sprintf("  CONSTRAINT %s", c.Def)
+				d := fmt.Sprintf(" CONSTRAINT %s", c.Def)
 				td = append(td, d)
 			}
 		}
-		ddl += fmt.Sprintf("%s\n", strings.Join(td, ",\n"))
+		ddl += strings.Join(td, ",")
 		if t.Comment != "" {
-			ddl += fmt.Sprintf(") COMMENT = %q;\n\n", t.Comment)
+			ddl += fmt.Sprintf(") COMMENT = %q;\n", t.Comment)
 		} else {
-			ddl += ");\n\n"
+			ddl += ");\n"
 		}
 	}
 	return ddl

--- a/openai/templates.go
+++ b/openai/templates.go
@@ -70,9 +70,9 @@ func generateDDLRoughly(s *schema.Schema) string {
 		}
 		ddl += strings.Join(td, ",")
 		if t.Comment != "" {
-			ddl += fmt.Sprintf(") COMMENT = %q;\n", t.Comment)
+			ddl += fmt.Sprintf(") COMMENT = %q;", t.Comment)
 		} else {
-			ddl += ");\n"
+			ddl += ");"
 		}
 	}
 	return ddl


### PR DESCRIPTION
OpenAI API counts line breaks and two sequences of white space as one token (see the results of tiktokens below).

It would help humans to read DDM, but I guess LLM does not need such readability.

Hence, I removed the unnnecessary line breaks and shite spaces to save LLM tokens.

## experimental results of tiktokens

Human friendly version 

```
import tiktoken

text = """
CREATE TABLE `employees_copy` (
  `emp_no` int(11) NOT NULL,
  `birth_date` date NOT NULL,
  `first_name` varchar(14) NOT NULL,
  `last_name` varchar(16) NOT NULL,
  `gender` enum('M','F') NOT NULL,
  `hire_date` date NOT NULL,
  PRIMARY KEY (emp_no)
);
"""

tiktoken_encoding = tiktoken.encoding_for_model("gpt-4o")
encoded = tiktoken_encoding.encode(text)
token_count = len(encoded)

print(token_count)
# 83
```

LLM friendly version

```
import tiktoken

text = """
CREATE TABLE `employees_copy` (`emp_no` int(11) NOT NULL,`birth_date` date NOT NULL,`first_name` varchar(14) NOT NULL,`last_name` varchar(16) NOT NULL,`gender` enum('M','F') NOT NULL,`hire_date` date NOT NULL,PRIMARY KEY (emp_no));
"""

tiktoken_encoding = tiktoken.encoding_for_model("gpt-4o")
encoded = tiktoken_encoding.encode(text)
token_count = len(encoded)

print(token_count)
# 74
```
