### PR TITLE
Update default chat model to "gpt-4o".

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultModelChat = "gpt-4-1106-preview"
+	DefaultModelChat = "gpt-4o"
 	quoteStart       = "```sql"
 	quoteEnd         = "```"
 )


### PR DESCRIPTION
Update the defualt chat model from "gpt-4-turbo" to "gpt-4o", which is better in the most use cases; faster and cheaper.

https://platform.openai.com/docs/models/gpt-4o