### PR TITLE
Viewpoint を template に渡せるようにする

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -59,6 +59,7 @@ func (g *Gemini) Ask(ctx context.Context, q string, s *schema.Schema) (string, e
 		"QuoteStart":      "```sql",
 		"QuoteEnd":        "```",
 		"DDL":             templates.GenerateDDLRoughly(s),
+		"Viewpoints":      templates.GenerateViewPoints(s),
 		"Question":        q,
 	}); err != nil {
 		return "", err
@@ -93,6 +94,7 @@ func (g *Gemini) AskQuery(ctx context.Context, q string, s *schema.Schema) (stri
 		"QuoteStart":      "```sql",
 		"QuoteEnd":        "```",
 		"DDL":             templates.GenerateDDLRoughly(s),
+		"Viewpoints":      templates.GenerateViewPoints(s),
 		"Question":        q,
 	}); err != nil {
 		return "", err

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -46,6 +46,7 @@ func (o *OpenAI) Ask(ctx context.Context, q string, s *schema.Schema) (string, e
 		"QuoteStart":      quoteStart,
 		"QuoteEnd":        quoteEnd,
 		"DDL":             templates.GenerateDDLRoughly(s),
+		"ViewPoints":      templates.GenerateViewPoints(s),
 		"Question":        q,
 	}); err != nil {
 		return "", err
@@ -78,6 +79,7 @@ func (o *OpenAI) AskQuery(ctx context.Context, q string, s *schema.Schema) (stri
 		"QuoteStart":      quoteStart,
 		"QuoteEnd":        quoteEnd,
 		"DDL":             templates.GenerateDDLRoughly(s),
+		"ViewPoints":      templates.GenerateViewPoints(s),
 		"Question":        q,
 	}); err != nil {
 		return "", err

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -17,6 +17,10 @@ const (
 {{ .DDL }}
 {{ .QuoteEnd }}
 
+## ViewPoints (Sets of tables based on specific concerns)
+
+{{ .ViewPoints }}
+
 ## Question
 {{ .Question }}
 `
@@ -76,6 +80,41 @@ func GenerateDDLRoughly(s *schema.Schema) string {
 		}
 	}
 	return ddl
+}
+
+func GenerateViewPoints(s *schema.Schema) string {
+	var output strings.Builder
+	for _, v := range s.Viewpoints {
+		output.WriteString(fmt.Sprintf("Viewpoint: %s\n", v.Name))
+		if v.Desc != "" {
+			output.WriteString(fmt.Sprintf("- Description: %s\n", v.Desc))
+		}
+		if len(v.Labels) > 0 {
+			output.WriteString(fmt.Sprintf("- Labels: %s\n", strings.Join(v.Labels, ", ")))
+		}
+		if len(v.Tables) > 0 {
+			output.WriteString(fmt.Sprintf("- Tables: %s\n", strings.Join(v.Tables, ", ")))
+		}
+		if v.Distance > 0 {
+			output.WriteString(fmt.Sprintf("- Distance: %d\n", v.Distance))
+		}
+		for _, g := range v.Groups {
+			output.WriteString(fmt.Sprintf("- Group: %s\n", g.Name))
+			if g.Desc != "" {
+				output.WriteString(fmt.Sprintf("  - Description: %s\n", g.Desc))
+			}
+			if len(g.Labels) > 0 {
+				output.WriteString(fmt.Sprintf("  - Labels: %s\n", strings.Join(g.Labels, ", ")))
+			}
+			if len(g.Tables) > 0 {
+				output.WriteString(fmt.Sprintf("  - Tables: %s\n", strings.Join(g.Tables, ", ")))
+			}
+			if g.Color != "" {
+				output.WriteString(fmt.Sprintf("  - Color: %s\n", g.Color))
+			}
+		}
+	}
+	return output.String()
 }
 
 func DatabaseVersion(s *schema.Schema) string {

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -77,3 +77,52 @@ func TestGenerateDDLRoughly(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateViewPoints(t *testing.T) {
+	tests := []struct {
+		s    *schema.Schema
+		want string
+	}{
+		{
+			&schema.Schema{
+				Name: "test",
+				Tables: []*schema.Table{
+					{
+						Name: "test",
+						Columns: []*schema.Column{
+							{
+								Name: "id",
+								Type: "int",
+							},
+							{
+								Name: "name",
+								Type: "varchar",
+							},
+						},
+					},
+				},
+				Viewpoints: []*schema.Viewpoint{
+					{
+						Name:        "test",
+						Desc: "test viewpoint",
+						Tables: []string{
+							"test",
+						},
+					},
+				},
+			},
+			`Viewpoint: test
+- Description: test viewpoint
+- Tables: test
+`,
+	},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := GenerateViewPoints(tt.s)
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
tbls の viewpoint を template に渡せるようにします

viewpoint のある schema を渡した場合、以下のようなセクションをtemplateに挿入します

```
## ViewPoints (Sets of tables based on specific concerns)

Viewpoint: 書籍の追加
 - Description: 書籍を追加する際に関連するテーブルのまとまり
 - Tables: public.books, public.products, public.publishers, public.authors, public.author_books, public.book_images

Viewpoint: 顧客の追加
 - Description: 顧客を追加する際に関連するテーブルのまとまり
 - Tables: public.customers

Viewpoint: 配送先の追加
- Description: 配送先を追加する際に関連するテーブルのまとまり
- Tables: public.shipping_addresses, public.customers

Viewpoint: 書籍の購入
- Description: 書籍を購入する際に関連するテーブルのまとまり。 顧客が購入できるためには、配送先が設定される必要がある。 配送時に参照される製品コードはproductsテーブルから取得される。
- Tables: public.books, public.products, public.customers, public.shipping_addresses, public.orders, public.order_items, public.books_view, public.author_ranking_materialized_view
- Group: View
  -   Description: 関連するビュー
  - Tables: public.books_view
- Group: Materialized View
  -   Description: 関連するマテリアライズドビュー
  -   Tables: public.author_ranking_materialized_view
```