### PR TITLE
support o1 (o3) models

### DIFF
--- a/chat/service.go
+++ b/chat/service.go
@@ -14,7 +14,7 @@ func NewService(model string) (*Service, error) {
 	var client Client
 	var err error
 
-	if strings.HasPrefix(model, "gpt") {
+	if strings.HasPrefix(model, "gpt") || strings.HasPrefix(model, "o") {
 		client, err = NewOpenAIClient(model)
 	} else if strings.HasPrefix(model, "gemini") {
 		client, err = NewGeminiClient(model)

--- a/chat/service_test.go
+++ b/chat/service_test.go
@@ -21,6 +21,7 @@ func TestNewService(t *testing.T) {
 		wantErr bool
 	}{
 		{"GPT model", "gpt-3.5-turbo", false},
+		{"GPT model with o", "o1-mini", false},
 		{"Gemini model", "gemini-pro", false},
 		{"Unsupported model", "unsupported-model", true},
 	}


### PR DESCRIPTION
Allows users to use the o1 and o3 series models, which were recently released by OpenAI.

ref: https://openai.com/index/openai-o3-mini/