### PR TITLE
Remove temperature setting from OpenAI client and change system role to user

### DIFF
--- a/chat/openai.go
+++ b/chat/openai.go
@@ -61,7 +61,6 @@ func (c *OpenAIClient) Ask(ctx context.Context, messages []Message) (string, err
 
 	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 		Model:       c.model,
-		Temperature: 0.5,
 		Messages:    openaiMessages,
 	})
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ var rootCmd = &cobra.Command{
 
 		messages := []chat.Message{
 			{
-				Role:    "system",
+				Role:    "user",
 				Content: "You are a database expert. You are given a database schema and a question. Answer the question based on the schema.",
 			},
 			{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k1LoW/tbls-ask
 
-go 1.22.10
+go 1.23.6
 
 require (
 	github.com/google/generative-ai-go v0.13.0


### PR DESCRIPTION
Open AI API `o-` models does not accept `Temperature` paremeter, and `system` role message.

As these options does not contributes to the quality of the answer so much, I removed these option so that we can use `o-` model in this package.